### PR TITLE
Bump time version

### DIFF
--- a/lambdacube-gl.cabal
+++ b/lambdacube-gl.cabal
@@ -125,7 +125,7 @@ executable lambdacube-gl-test-client
     base < 5,
     containers >=0.5 && <0.6,
     text >= 1.2 && <1.3,
-    time >= 1.5 && <1.6,
+    time >= 1.5 && <1.7,
     exceptions >= 0.8 && <0.9,
     bytestring >=0.10 && <0.11,
     base64-bytestring >=1 && <1.1,


### PR DESCRIPTION
Hi, just hit problem that `time` bound for test client is too restrictive for current stackage snapshots.