### PR TITLE
Fix space leak, as per #11

### DIFF
--- a/src/LambdaCube/GL/Input.hs
+++ b/src/LambdaCube/GL/Input.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE BangPatterns, FlexibleContexts, TypeSynonymInstances, FlexibleInstances #-}
 module LambdaCube.GL.Input where
 
 import Control.Applicative
@@ -117,7 +117,7 @@ addObject input slotName prim indices attribs uniformNames = do
             , objCommands   = cmdsRef
             }
 
-    modifyIORef (slotVector input ! slotIdx) $ \(GLSlot objs _ _) -> GLSlot (IM.insert index obj objs) V.empty Generate
+    modifyIORef' (slotVector input ! slotIdx) $ \(GLSlot objs _ _) -> GLSlot (IM.insert index obj objs) V.empty Generate
 
     -- generate GLObjectCommands for the new object
     {-
@@ -144,7 +144,7 @@ addObject input slotName prim indices attribs uniformNames = do
     return obj
 
 removeObject :: GLStorage -> Object -> IO ()
-removeObject p obj = modifyIORef (slotVector p ! objSlot obj) $ \(GLSlot objs _ _) -> GLSlot (IM.delete (objId obj) objs) V.empty Generate
+removeObject p obj = modifyIORef (slotVector p ! objSlot obj) $ \(GLSlot !objs _ _) -> GLSlot (IM.delete (objId obj) objs) V.empty Generate
 
 enableObject :: Object -> Bool -> IO ()
 enableObject obj b = writeIORef (objEnabled obj) b

--- a/src/LambdaCube/GL/Mesh.hs
+++ b/src/LambdaCube/GL/Mesh.hs
@@ -7,7 +7,7 @@ module LambdaCube.GL.Mesh (
     Mesh(..),
     MeshPrimitive(..),
     MeshAttribute(..),
-    GPUMesh,
+    GPUMesh(..), GPUData(..),
     meshData
 ) where
 


### PR DESCRIPTION
Repro in https://github.com/deepfire/holotype/commit/db5402b52142d43cd5914ef2f3d4c0313a3aac0b
  - issue (stats show increasing memory usage):     
    - `make lcstress SCENARIO=ManMeshObjOrig`
    - code: https://github.com/deepfire/holotype/commit/db5402b52142d43cd5914ef2f3d4c0313a3aac0b#diff-0c51adfe0c36c420c9b8e7d5d83d9d50R104
  - issue fixed (flat memory usage):
    - `make lcstress SCENARIO=ManMeshObj`
    - code: https://github.com/deepfire/holotype/commit/db5402b52142d43cd5914ef2f3d4c0313a3aac0b#diff-0c51adfe0c36c420c9b8e7d5d83d9d50R100

Also exports a couple internal structures: `GL.Mesh.GPUMesh` and `GL.Mesh.GPUData`,
as without them it was a bit too painful to develop a solution.

cc @csabahruska #