### PR TITLE
Compatibility with new version of Foreign

### DIFF
--- a/src/LambdaCube/GL/Util.hs
+++ b/src/LambdaCube/GL/Util.hs
@@ -46,7 +46,7 @@ import qualified Data.Map as Map
 
 import Graphics.GL.Core33
 import LambdaCube.Linear
-import LambdaCube.IR
+import LambdaCube.IR as IR
 import LambdaCube.PipelineSchema
 import LambdaCube.GL.Type
 
@@ -360,22 +360,22 @@ comparisonFunctionToGLType a = case a of
 
 logicOperationToGLType :: LogicOperation -> GLenum
 logicOperationToGLType a = case a of
-    And             -> GL_AND
-    AndInverted     -> GL_AND_INVERTED
-    AndReverse      -> GL_AND_REVERSE
-    Clear           -> GL_CLEAR
-    Copy            -> GL_COPY
-    CopyInverted    -> GL_COPY_INVERTED
-    Equiv           -> GL_EQUIV
-    Invert          -> GL_INVERT
-    Nand            -> GL_NAND
-    Noop            -> GL_NOOP
-    Nor             -> GL_NOR
-    Or              -> GL_OR
-    OrInverted      -> GL_OR_INVERTED
-    OrReverse       -> GL_OR_REVERSE
-    Set             -> GL_SET
-    Xor             -> GL_XOR
+    IR.And             -> GL_AND
+    IR.AndInverted     -> GL_AND_INVERTED
+    IR.AndReverse      -> GL_AND_REVERSE
+    IR.Clear           -> GL_CLEAR
+    IR.Copy            -> GL_COPY
+    IR.CopyInverted    -> GL_COPY_INVERTED
+    IR.Equiv           -> GL_EQUIV
+    IR.Invert          -> GL_INVERT
+    IR.Nand            -> GL_NAND
+    IR.Noop            -> GL_NOOP
+    IR.Nor             -> GL_NOR
+    IR.Or              -> GL_OR
+    IR.OrInverted      -> GL_OR_INVERTED
+    IR.OrReverse       -> GL_OR_REVERSE
+    IR.Set             -> GL_SET
+    IR.Xor             -> GL_XOR
 
 blendEquationToGLType :: BlendEquation -> GLenum
 blendEquationToGLType a = case a of


### PR DESCRIPTION
In newer dependency versions, `Foreign` exports `And` and `Xor`; for full backwards and forwards compatibility, this solution qualifies the use of `LambdaCube.IR.LogicOperation` constructors.

With this plus #14, it will be possible to extend the upper version bounds to allow these current dependency versions (most of these are still in range but there's a few to loosen):

- JuicyPixels-3.3.7
- OpenGLRaw-3.3.4.1
- base-4.16.4.0
- bytestring-0.11.4.0
- containers-0.6.5.1
- lambdacube-ir-0.3.0.1
- mtl-2.2.2
- vector-0.12.3.1
- vector-algorithms-0.8.0.4
