### PR TITLE
Add support for meshes of line and triangle-fan types

### DIFF
--- a/src/LambdaCube/GL/Mesh.hs
+++ b/src/LambdaCube/GL/Mesh.hs
@@ -106,7 +106,11 @@ uploadMeshToGPU mesh@(Mesh attrs mPrim) = do
     vBuf <- compileBuffer [meshAttrToArray a | a <- Map.elems attrs]
     (indices,prim) <- case mPrim of
         P_Points            -> return (Nothing,PointList)
+        P_Lines             -> return (Nothing,LineList)
+        P_LineStrip         -> return (Nothing,LineStrip)
+        P_LineLoop          -> return (Nothing,LineLoop)
         P_TriangleStrip     -> return (Nothing,TriangleStrip)
+        P_TriangleFan       -> return (Nothing,TriangleFan)
         P_Triangles         -> return (Nothing,TriangleList)
         P_TriangleStripI v  -> (,TriangleStrip) <$> mkIndexBuf v
         P_TrianglesI v      -> (,TriangleList) <$> mkIndexBuf v

--- a/src/LambdaCube/GL/Type.hs
+++ b/src/LambdaCube/GL/Type.hs
@@ -464,6 +464,7 @@ data Primitive
     | TriangleFan
     | LineStrip
     | LineList
+    | LineLoop
     | PointList
     | TriangleStripAdjacency
     | TriangleListAdjacency

--- a/src/LambdaCube/GL/Util.hs
+++ b/src/LambdaCube/GL/Util.hs
@@ -695,6 +695,7 @@ primitiveToFetchPrimitive prim = case prim of
     TriangleFan             -> Triangles
     LineStrip               -> Lines
     LineList                -> Lines
+    LineLoop                -> Lines
     PointList               -> Points
     TriangleStripAdjacency  -> TrianglesAdjacency
     TriangleListAdjacency   -> TrianglesAdjacency
@@ -708,6 +709,7 @@ primitiveToGLType p = case p of
     TriangleFan             -> GL_TRIANGLE_FAN
     LineStrip               -> GL_LINE_STRIP
     LineList                -> GL_LINES
+    LineLoop                -> GL_LINE_LOOP
     PointList               -> GL_POINTS
     TriangleStripAdjacency  -> GL_TRIANGLE_STRIP_ADJACENCY
     TriangleListAdjacency   -> GL_TRIANGLES_ADJACENCY


### PR DESCRIPTION
including adding the line loop type.

Resolves #17 

Requires https://github.com/lambdacube3d/lambdacube-ir/pull/9 OR https://github.com/lambdacube3d/lambdacube-ir/pull/10

Tested locally by patching both packages and using line loop mesh type in a program.